### PR TITLE
Fix/refused users

### DIFF
--- a/src/mnms/flow/user_flow.py
+++ b/src/mnms/flow/user_flow.py
@@ -8,6 +8,7 @@ from mnms.demand.user import User, UserState
 # from mnms.graph.core import ConnectionLink, TransitLink
 from mnms.time import Dt, Time
 from mnms.log import create_logger
+from mnms.mobility_service.abstract import AbstractMobilityService
 
 log = create_logger(__name__)
 

--- a/src/mnms/mobility_service/abstract.py
+++ b/src/mnms/mobility_service/abstract.py
@@ -84,7 +84,10 @@ class AbstractMobilityService(ABC):
         return create_service_costs()
 
     def request_vehicle(self, user: "User", drop_node:str) -> None:
-        self._user_buffer[user.id] = (user, drop_node)
+        self._user_buffer[user.id] = (user, drop_node) #NB: works only for at most one simulatneous request per user...
+
+    def cancel_request(self, uid: str) -> None:
+        self._user_buffer.pop(uid)
 
     def update(self, dt: Dt):
         self.step_maintenance(dt)
@@ -117,7 +120,7 @@ class AbstractMobilityService(ABC):
                     self._user_buffer.pop(uid)
                 else:
                     # If pick-up time exceeds passengers' waiting tolerance
-                    log.info(f"{uid} refused {self.id} offer (predicted pickup time too long)")
+                    log.info(f"{uid} refused {self.id} offer (predicted pickup time too long, wait for better proposition...")
                     # user.set_state_stop()
                     # user.notify(self._tcurrent)
                     # Therefuse_user.append(user)

--- a/src/mnms/travel_decision/abstract.py
+++ b/src/mnms/travel_decision/abstract.py
@@ -157,6 +157,7 @@ class AbstractDecisionModel(ABC):
                     u.available_mobility_service.remove(personal_mob_service)
             # Check if user has no remaining available mobility_service
             if len(u.available_mobility_service) == 0:
+                log.warning(f'{u.id} has no more available mobility service to continue her path')
                 continue
 
             # Create a new user representing refused user legacy
@@ -172,9 +173,10 @@ class AbstractDecisionModel(ABC):
     # TODO: restrict combination of paths (ex: we dont want Uber->Bus)
     def __call__(self, new_users: List[User], tcurrent: Time):
         legacy_users = self._check_refused_users(tcurrent)
+        log.info(f'There are {len(new_users)} new users and {len(legacy_users)} legacy users')
         all_users = legacy_users+new_users
 
-        if len(new_users)>0:
+        if len(all_users)>0:
             origins, destinations, available_layers, chosen_services = _process_shortest_path_inputs(self._mlgraph, all_users)
             paths = parallel_k_shortest_path(self._mlgraph.graph,
                                              origins,
@@ -191,7 +193,7 @@ class AbstractDecisionModel(ABC):
 
             for i, kpath in enumerate(paths):
                 user_paths = []
-                user = new_users[i]
+                user = all_users[i]
                 path_index = 0
                 for p in kpath:
                     if p[0]:
@@ -245,7 +247,7 @@ class AbstractDecisionModel(ABC):
                         log.warning(f"Path %s is not valid for %s", str(path), user.id)
                         raise PathNotFound(user.origin, user.destination)
 
-                    log.info(f"Computed path for %s", user.id)
+                    log.info(f"Computed path for {user.id} is {path}")
 
                     if self._verbose_file:
                         for p in user_paths:


### PR DESCRIPTION
This fix should solve the problems due to the fact that we do not clean the _user_buffer  of mobility services anymore. Indeed, while this clear was removed, there is no other element to cancel the request once user has reached its response_dt. So I added a cancel_request  method to remove user's request at this moment. In this way, the service stops to try to match with this user. Moreover, in the _call_  method of the abstract travel decision model, we should compute the paths for new users AND legacy users, not only new users.